### PR TITLE
Limit both total scheduled and AT basal to 1 fraction digit

### DIFF
--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
@@ -16,7 +16,7 @@ extension AutotuneConfig {
         private var rateFormatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
-            formatter.maximumFractionDigits = 2
+            formatter.maximumFractionDigits = 1
             return formatter
         }
 

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
@@ -16,7 +16,7 @@ extension AutotuneConfig {
         private var rateFormatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
-            formatter.maximumFractionDigits = 1
+            formatter.maximumFractionDigits = 2
             return formatter
         }
 

--- a/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
+++ b/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
@@ -17,7 +17,7 @@ extension BasalProfileEditor {
         private var rateFormatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
-            formatter.maximumFractionDigits = 1
+            formatter.maximumFractionDigits = 2
             return formatter
         }
 

--- a/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
+++ b/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
@@ -17,6 +17,7 @@ extension BasalProfileEditor {
         private var rateFormatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
+            formatter.maximumFractionDigits = 2
             return formatter
         }
 

--- a/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
+++ b/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
@@ -17,7 +17,7 @@ extension BasalProfileEditor {
         private var rateFormatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
-            formatter.maximumFractionDigits = 2
+            formatter.maximumFractionDigits = 1
             return formatter
         }
 


### PR DESCRIPTION
Nearest 0,1 U/day is precise enough for the sum of daily basals. Added restriction also for scheduled basal.